### PR TITLE
Escape HTML comment markers in embedded JSON

### DIFF
--- a/boss.py
+++ b/boss.py
@@ -403,7 +403,7 @@ function render(){
   });
 
   document.getElementById("pageInfo").textContent =
-    \`Page \${state.page} of \${pages} — \${total} group\${total===1?"":"s"}\`;
+    `Page ${state.page} of ${pages} — ${total} group${total===1?"":"s"}`;
   document.getElementById("prevBtn").disabled = state.page<=1;
   document.getElementById("nextBtn").disabled = state.page>=pages;
 }
@@ -428,16 +428,18 @@ render();
 def _js_escape(s: str) -> str:
     """Escape JSON for embedding inside a <script> tag.
 
-    Browsers treat certain characters (U+2028, U+2029, ``</``) specially when
-    parsing JavaScript inside HTML.  If these appear unescaped in our JSON data
-    the generated ``rxnorm_boss_view.html`` can produce ``SyntaxError`` when
-    loaded in a browser.  ``json.dumps`` with ``ensure_ascii=False`` will emit
-    those characters verbatim, so we replace them with escaped sequences that
-    JavaScript can safely evaluate.
+    Browsers treat certain characters (U+2028, U+2029, ``</``, ``<!--``, ``-->``)
+    specially when parsing JavaScript inside HTML. If these appear unescaped in
+    our JSON data the generated ``rxnorm_boss_view.html`` can produce
+    ``SyntaxError`` when loaded in a browser. ``json.dumps`` with
+    ``ensure_ascii=False`` will emit those characters verbatim, so we replace
+    them with escaped sequences that JavaScript can safely evaluate.
     """
     return (
         s.replace("\u2028", "\\u2028")
          .replace("\u2029", "\\u2029")
+         .replace("<!--", "<\\!--")
+         .replace("-->", "--\\>")
          .replace("</", "<\\/")
     )
 

--- a/tests/test_js_escape.py
+++ b/tests/test_js_escape.py
@@ -1,0 +1,26 @@
+import json
+import unittest
+
+from boss import _js_escape
+
+
+class JsEscapeTests(unittest.TestCase):
+    def test_escape_html_comment_sequences(self):
+        data = "<!-- tricky -->"
+        dumped = json.dumps(data, ensure_ascii=False)
+        escaped = _js_escape(dumped)
+        self.assertNotIn("<!--", escaped)
+        self.assertNotIn("-->", escaped)
+        self.assertIn("<\\!--", escaped)
+        self.assertIn("--\\>", escaped)
+
+    def test_escape_script_close(self):
+        data = "</script>"
+        dumped = json.dumps(data, ensure_ascii=False)
+        escaped = _js_escape(dumped)
+        self.assertNotIn("</", escaped)
+        self.assertIn("<\\/", escaped)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Escape `<!--` and `-->` sequences when embedding JSON in the viewer to prevent browser `SyntaxError`
- Remove spurious escapes in page info template literal
- Add unit tests verifying escaping of HTML comment and `</script>` sequences

## Testing
- `python -m unittest discover -s tests`
- `python -m py_compile boss.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_689e2a88a9848327ae087f1e8df26db7