### PR TITLE
Add percentages for differing AI and AM

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is importable
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_compute_stats.py
+++ b/tests/test_compute_stats.py
@@ -1,0 +1,32 @@
+import unittest
+
+from boss import compute_stats
+
+
+class ComputeStatsTests(unittest.TestCase):
+    def test_ai_am_different_boss_from_percentages(self):
+        rows = [
+            {"ai": [{"rxcui": "1"}], "am": [{"rxcui": "2"}], "boss_from": ["AI"]},
+            {"ai": [{"rxcui": "1"}], "am": [{"rxcui": "1"}], "boss_from": ["AM"]},
+            {"ai": [{"rxcui": "1"}], "am": [{"rxcui": "2"}], "boss_from": ["AM"]},
+            {"ai": [{"rxcui": "1"}], "am": [{"rxcui": "2"}], "boss_from": []},
+        ]
+        stats = compute_stats(rows)
+        self.assertEqual(stats["ai_am_different"]["count"], 3)
+        self.assertAlmostEqual(stats["ai_am_different"]["pct"], 75.0)
+        self.assertEqual(
+            stats["boss_from_AI_when_ai_am_different"]["count"], 1
+        )
+        self.assertAlmostEqual(
+            stats["boss_from_AI_when_ai_am_different"]["pct"], 33.333333, places=5
+        )
+        self.assertEqual(
+            stats["boss_from_AM_when_ai_am_different"]["count"], 1
+        )
+        self.assertAlmostEqual(
+            stats["boss_from_AM_when_ai_am_different"]["pct"], 33.333333, places=5
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track groups where AI and AM ingredient sets differ
- report BOSS_FROM percentages for AI and AM on those groups
- expose stats in HTML summary table and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e351c03fc832794c39ac62d85c379