### PR TITLE
Identify parent drugs with multiple SCDC components

### DIFF
--- a/boss.py
+++ b/boss.py
@@ -193,6 +193,19 @@ def compute_stats(rows: List[dict]) -> dict:
     boss_ai_diff = sum(1 for r in diff_rows if "AI" in r["boss_from"])
     boss_am_diff = sum(1 for r in diff_rows if "AM" in r["boss_from"])
 
+    # parents that reference more than one distinct SCDC
+    parent_scdc_map = {}
+    for r in rows:
+        parent_rxcui = r.get("parent", {}).get("rxcui")
+        scdc_rxcui = r.get("scdc", {}).get("rxcui")
+        if parent_rxcui and scdc_rxcui:
+            parent_scdc_map.setdefault(
+                parent_rxcui, {"parent": r["parent"], "scdcs": set()}
+            )["scdcs"].add(scdc_rxcui)
+    multi_scdc_parents = [
+        info["parent"] for info in parent_scdc_map.values() if len(info["scdcs"]) > 1
+    ]
+
     def pct(x): return (100.0 * x / n) if n else 0.0
     def pct_diff(x): return (100.0 * x / diff) if diff else 0.0
 
@@ -217,6 +230,10 @@ def compute_stats(rows: List[dict]) -> dict:
         "boss_from_AM_when_ai_am_different": {
             "count": boss_am_diff,
             "pct": pct_diff(boss_am_diff),
+        },
+        "parents_with_multiple_scdcs": {
+            "count": len(multi_scdc_parents),
+            "parents": multi_scdc_parents,
         },
     }
 

--- a/tests/test_compute_stats.py
+++ b/tests/test_compute_stats.py
@@ -27,6 +27,17 @@ class ComputeStatsTests(unittest.TestCase):
             stats["boss_from_AM_when_ai_am_different"]["pct"], 33.333333, places=5
         )
 
+    def test_parents_with_multiple_scdcs(self):
+        rows = [
+            {"parent": {"rxcui": "10"}, "scdc": {"rxcui": "100"}, "ai": [], "am": [], "boss_from": []},
+            {"parent": {"rxcui": "10"}, "scdc": {"rxcui": "101"}, "ai": [], "am": [], "boss_from": []},
+            {"parent": {"rxcui": "11"}, "scdc": {"rxcui": "102"}, "ai": [], "am": [], "boss_from": []},
+        ]
+        stats = compute_stats(rows)
+        self.assertEqual(stats["parents_with_multiple_scdcs"]["count"], 1)
+        parents = {p["rxcui"] for p in stats["parents_with_multiple_scdcs"]["parents"]}
+        self.assertEqual(parents, {"10"})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- detect parent SCD/SBD concepts that reference more than one SCDC component
- expose new `parents_with_multiple_scdcs` entry in computed stats
- test detection of multi-SCDC parents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e35ecd3ac8327b48478dccb6350d9